### PR TITLE
Fix import bug in package initializer

### DIFF
--- a/src/WhenWasThat/__init__.py
+++ b/src/WhenWasThat/__init__.py
@@ -2,6 +2,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from WhenWasThat import when
+"""Convenience imports for the package."""
 
-when = when.whenWasThat
+# Import the main :class:`whenWasThat` class using a relative import so that the
+# package works whether it is installed or run directly from the source tree.
+from .when import whenWasThat
+
+# Expose the class under the short name ``when`` to mirror the examples in the
+# project documentation.
+when = whenWasThat
+
+__all__ = ["whenWasThat", "when"]


### PR DESCRIPTION
## Summary
- fix package-level imports by using relative import in `__init__.py`
- expose `whenWasThat` and alias `when`

## Testing
- `PYTHONPATH=src python test.py | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6845a3c9345c832688d343227a39b00b