### PR TITLE
Handle dynamic time_now default

### DIFF
--- a/src/WhenWasThat/when.py
+++ b/src/WhenWasThat/when.py
@@ -4,7 +4,9 @@ import pandas as pd
 class whenWasThat:
     '''When was that?'''
 
-    def __init__(self, time_then, time_now = dt.datetime.now()):
+    def __init__(self, time_then, time_now=None):
+        if time_now is None:
+            time_now = dt.datetime.now()
         self.time_then = time_then
         self.time_now = time_now
         self.new_delta = abs(time_now - time_then)


### PR DESCRIPTION
## Summary
- set `time_now` to `None` by default
- compute `time_now` when constructing `whenWasThat`

## Testing
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_6846b6b37d208326b9e0e192d5d3ffe1